### PR TITLE
[#258]Updated index.html to process only the rectangle instead of the entire image

### DIFF
--- a/Tutorials/pixels/index.html
+++ b/Tutorials/pixels/index.html
@@ -586,8 +586,8 @@ def draw():
     matrixsize = 3
     loadPixels()
     # Begin our loop for every pixel
-    for x in xrange(xend):
-        for y in xrange(yend):
+    for x in xrange(xstart,xend):
+        for y in xrange(ystart,yend):
             # Each pixel location (x,y) gets passed into a function called convolution() 
             # which returns a new color value to be displayed.
             c = convolution(x,y,matrix,matrixsize,img)


### PR DESCRIPTION
Fixes https://github.com/jdf/processing.py/issues/258.The main loop was set to process the entire image until the position of the mouse,instead of just the rectangle.Fixed it using **xstart** and **ystart** as the starting positing in the function.