### PR TITLE
Add advice for immediate termination with exit

### DIFF
--- a/Reference/api_en/exit.xml
+++ b/Reference/api_en/exit.xml
@@ -25,6 +25,7 @@ Quits/stops/exits the program. Programs without a <b>draw()</b> function exit au
 <br />
 Rather than terminating immediately, <b>exit()</b> will cause the sketch to exit after <b>draw()</b> has completed (or after <b>setup()</b> completes if called during the <b>setup()</b> function).<br />
 <br />
+To terminate immediately in the middle of setup() or draw(): call <b>exit()</b> followed  by <b>return</b>
 ]]></description>
 
 <syntax>


### PR DESCRIPTION
exit() in Python mode has surprising behavior compared to the Java API, in that it continues to execute for the rest of setup or the rest of the draw loop. This is already documented, but the proposed addition adds a line of advice for people who want the immediate termination behavior typical in other modes.