### PR TITLE
reference: add circle() and square() 

### DIFF
--- a/Reference/api_en/circle.xml
+++ b/Reference/api_en/circle.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<root>
+<name>circle()</name>
+
+<category>Shape</category>
+
+<subcategory>2D Primitives</subcategory>
+
+<type></type>
+
+<example>
+<image />
+<code><![CDATA[
+ellipse(56, 46, 55, 55)
+]]></code>
+</example>
+
+<description><![CDATA[
+Draws a circle to the screen. By default, the first two parameters set the location of the center, and the third sets the shape's width and height. The origin may be changed with the <b>ellipseMode()</b> function.
+]]></description>
+
+<syntax>
+circle(<c>a</c>, <c>b</c>, <c>extent</c>)
+</syntax>
+
+<parameter>
+<label>a</label>
+<description><![CDATA[float: x-coordinate of the circle]]></description>
+</parameter>
+
+<parameter>
+<label>b</label>
+<description><![CDATA[float: y-coordinate of the circle]]></description>
+</parameter>
+
+<parameter>
+<label>extent</label>
+<description><![CDATA[float: width and height of the circle by default]]></description>
+</parameter>
+
+<related>ellipse</related>
+<related>ellipseMode</related>

--- a/Reference/api_en/square.xml
+++ b/Reference/api_en/square.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<root>
+<name>square()</name>
+
+<category>Shape</category>
+
+<subcategory>2D Primitives</subcategory>
+
+<type></type>
+
+<example>
+<image />
+<code><![CDATA[
+square(10, 10, 55)
+]]></code>
+</example>
+
+<description><![CDATA[
+Draws a square to the screen. A square is a four-sided shape with every angle at ninety degrees and each side is the same length. By default, the first two parameters set the location of the upper-left corner, the third sets the width and height. The way these parameters are interpreted, however, may be changed with the <b>rectMode()</b> function.<br />
+]]></description>
+
+<syntax>
+square(<c>a</c>, <c>b</c>, <c>extent</c>)
+</syntax>
+
+<parameter>
+<label>a</label>
+<description><![CDATA[float: x-coordinate of the square by default]]></description>
+</parameter>
+
+<parameter>
+<label>b</label>
+<description><![CDATA[float: y-coordinate of the square by default]]></description>
+</parameter>
+
+<parameter>
+<label>extent</label>
+<description><![CDATA[float: extent of the square by default]]></description>
+</parameter>
+
+<related>rect</related>
+<related>rectMode</related>


### PR DESCRIPTION
closes #131 "New circle() and square() functions are missing in the reference"